### PR TITLE
fix: enable renovate with proper order of rules

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,10 +7,16 @@
   ],
   "packageRules": [
     {
+      "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "all non-major dependency bump",
+      "groupSlug": "all-patch",
+      "automerge": true
+    },
+    {
       "extends": "packages:linters",
       "groupName": "linters",
-      "automerge": true,
-      "automergeType": "branch"
+      "automerge": true
     },
     {
       "extends": "packages:postcss",
@@ -19,26 +25,16 @@
     {
       "extends": "packages:test",
       "groupName": "test packages",
-      "automerge": true,
-      "automergeType": "branch"
-    },
-    {
-      "groupName": "definitelyTyped",
-      "matchPackagePrefixes": ["@types/"],
-      "automerge": true,
-      "automergeType": "branch"
+      "automerge": true
     },
     {
       "groupName": "vitest",
       "matchPackagePrefixes": ["@vitest/", "vitest"]
     },
     {
-      "matchPackagePatterns": ["*"],
-      "matchUpdateTypes": ["patch"],
-      "groupName": "all non-major dependency bump",
-      "groupSlug": "all-patch",
-      "automerge": true,
-      "automergeType": "branch"
+      "groupName": "definitelyTyped",
+      "matchPackagePrefixes": ["@types/"],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
This PR fixes renovate custom config, previously it wasn't working as expected because `"automergeType": "branch"` and order of rules. Most generic rules should be on top of rule set